### PR TITLE
Alternative to #9: Use URLLib to join REST API paths

### DIFF
--- a/smart_cart_api_server/controllers/destination_complete.py
+++ b/smart_cart_api_server/controllers/destination_complete.py
@@ -4,6 +4,7 @@ import json
 from fastapi import HTTPException
 from api_server.models.alerts import AlertRequest
 from smart_cart_api_server.controllers.robot_status import get_robot_status
+from urllib.parse import urljoin
 
 
 # Placeholder for RMF communication function
@@ -19,7 +20,7 @@ async def notify_rmf_destination_complete(cart_id: str, destination: str, succes
             raise  HTTPException(status_code=500, detail=f"No task underway")
 
         #post_body = {"task_id": status.task.taskId, "location": destination, "success": success}
-        async with session.get(f"{api_server}alerts/requests/task/{status.task.taskId}") as response:
+        async with session.get(urljoin(api_server, f"alerts/requests/task/{status.task.taskId}")) as response:
 
             if response.status != 200:
                 raise HTTPException(status_code=500, detail=f"got error from remote server")
@@ -30,7 +31,7 @@ async def notify_rmf_destination_complete(cart_id: str, destination: str, succes
             alert = AlertRequest.parse_obj(alerts[0])
 
             success = "success" if success else "fail"
-            async with session.post(f"{api_server}alerts/request/{alert.id}/respond?response={success}") as response:
+            async with session.post(urljoin(api_server, f"alerts/request/{alert.id}/respond?response={success}")) as response:
                 if response.status != 201:
                     raise  HTTPException(status_code=500, detail=f"got error from remote server")
             return

--- a/smart_cart_api_server/controllers/robot_status.py
+++ b/smart_cart_api_server/controllers/robot_status.py
@@ -5,7 +5,7 @@ import aiohttp
 import datetime
 import json
 from fastapi import HTTPException
-
+from urllib.parse import urljoin
 
 async def get_robot_status(
     robot_id: str,
@@ -18,7 +18,7 @@ async def get_robot_status(
     headers = headers or {}
     curr_robot = None
     async with aiohttp.ClientSession() as session:
-        async with session.get(f"{api_server}fleets") as response:
+        async with session.get(urljoin(api_server, "fleets")) as response:
 
             fleets = json.loads(await response.text())
 

--- a/smart_cart_api_server/controllers/task_status.py
+++ b/smart_cart_api_server/controllers/task_status.py
@@ -5,13 +5,13 @@ import datetime
 import aiohttp
 from parse import parse
 from fastapi import HTTPException
-
+from urllib.parse import urljoin
 
 async def get_task_status(
     task_id: str, api_server: str, headers: dict[str, str]
 ) -> TaskStatus | None:
     async with aiohttp.ClientSession(headers=headers) as session:
-        async with session.get(f"{api_server}tasks?task_id={task_id}") as response:
+        async with session.get(urljoin(api_server, f"tasks?task_id={task_id}")) as response:
             if response.status != 200:
                 raise HTTPException(
                     status_code=500, detail=f"got error from remote server"


### PR DESCRIPTION
This PR is an alternative to #9. It uses urlib to join paths.

Signed-off-by: Arjo Chakravarty <arjoc@google.com>
