### PR TITLE
Use current time for time stamps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 keycloak_config.json
+dist/

--- a/smart_cart_api_server/controllers/task_status.py
+++ b/smart_cart_api_server/controllers/task_status.py
@@ -61,9 +61,7 @@ def parse_task_status(task_state: str) -> TaskStatus | None:
     if state.phases is None:
         return TaskStatus(
             taskId=state.booking.id,
-            dateTime=datetime.datetime.fromtimestamp(
-                state.unix_millis_start_time, tz=datetime.timezone.utc
-            ),
+            dateTime=datetime.datetime.now(),
             robotId=state.assigned_to.name,
             fleetId=state.assigned_to.group,
             cartId=state.assigned_to.name,  # For now only use cart_id
@@ -113,9 +111,7 @@ def parse_task_status(task_state: str) -> TaskStatus | None:
 
     return TaskStatus(
         taskId=state.booking.id,
-        dateTime=datetime.datetime.fromtimestamp(
-            state.unix_millis_start_time, tz=datetime.timezone.utc
-        ),
+        dateTime=datetime.datetime.now(),
         robotId=state.assigned_to.name,
         fleetId=state.assigned_to.group,
         cartId=state.assigned_to.name,  # For now only use cart_id


### PR DESCRIPTION

<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix

### Fixed bug

`unix_millis_start_time` will not change once the task has started, we should still be providing the current time stamp then

@arjo129 the initial bug that caused the time stamp to fail was the `datetime.datetime.fromtimestamp` expects seconds instead of milliseconds, hence it complained about year 5000+