### PR TITLE
Support staging mode, where we notify the smart cart to wait indefinitely

### DIFF
--- a/smart_cart_api_server/controllers/task_status.py
+++ b/smart_cart_api_server/controllers/task_status.py
@@ -77,7 +77,7 @@ def parse_task_status(task_state: str) -> TaskStatus | None:
         )
 
     # This is under the assumption that phase keys are always stringified integers
-    for p in sorted(state.phases.keys(), key=lambda x: int(x)):
+    for p in sorted(state.phases.keys()):
         ### LOTS OF MAGIC
         x = json.loads(state.phases[p].detail.__root__)[0]
         if x["category"] == "Perform action":

--- a/smart_cart_api_server/controllers/task_status.py
+++ b/smart_cart_api_server/controllers/task_status.py
@@ -76,7 +76,8 @@ def parse_task_status(task_state: str) -> TaskStatus | None:
             taskType=task_type
         )
 
-    for p in sorted(state.phases.keys()):
+    # This is under the assumption that phase keys are always stringified integers
+    for p in sorted(state.phases.keys(), key=lambda x: int(x)):
         ### LOTS OF MAGIC
         x = json.loads(state.phases[p].detail.__root__)[0]
         if x["category"] == "Perform action":
@@ -86,16 +87,23 @@ def parse_task_status(task_state: str) -> TaskStatus | None:
             )
             loc_idxs[p] = len(locations)
             locations.append(
-                TaskDestination(name=res["place"], compartment=None, action="pickup")
+                TaskDestination(name=res["place"], compartment=None, action="pickup", staging=False)
             )
         else:
             next_loc_idx[p] = len(locations)
 
+    # These workflows are extremely specific to the task types
     if task_type == "single-pickup-multi-dropoff":
+        # First pickup and final dropoff will notify the smart cart to wait
+        # indefinitely
+        locations[0].staging = True
+        locations[-1].staging = True
         for i in range(1, len(locations)):
            locations[i].action = "dropoff"
-    else:
+    elif task_type == "multi-pickup-single-dropoff":
+        # Final dropoff will notify the smart cart to wait indefinitely
         locations[-1].action = "dropoff"
+        locations[-1].staging = True
 
     current_location = None
     traveling_to = None

--- a/smart_cart_api_server/models/robot_status.py
+++ b/smart_cart_api_server/models/robot_status.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI, HTTPException, Depends, Query
 from datetime import datetime
 from pydantic import BaseModel, Field
 from typing import Optional
-from smart_cart_api_server.models.task_status import TaskStatus, Location
+from smart_cart_api_server.models.task_status import TaskStatus, TaskDestination
 
 # Data Models (adjust if needed, based on your RMF integration)
 class RobotStatus(BaseModel):
@@ -10,8 +10,8 @@ class RobotStatus(BaseModel):
     robotId: str
     batteryPercentage: int
     robotState: str  # "idle", "working", etc.
-    currentLocation: Optional[Location] = None
-    travellingTo: Optional[Location] = None
+    currentLocation: Optional[TaskDestination] = None
+    travellingTo: Optional[TaskDestination] = None
     task: Optional[TaskStatus] = None
 
 

--- a/smart_cart_api_server/models/task_status.py
+++ b/smart_cart_api_server/models/task_status.py
@@ -4,20 +4,17 @@ from typing import Optional, List
 
 
 # Data Models (adjust if needed)
-class Location(BaseModel):
-    name: str
-    compartment: Optional[str] = None
-
 class TaskDestination(BaseModel):
     name: str
     compartment: Optional[str] = None
     action: str  # "pickup", "dropoff"
+    staging: bool
 
 class TaskStatus(BaseModel):
     taskId: str
     taskType: str
     dateTime: datetime
-    robotId: str 
+    robotId: str
     fleetId: str
     cartId: str
     destinations: list[TaskDestination]


### PR DESCRIPTION
## New feature implementation

### Implemented feature

The `staging` flag is a way to tell the smart cart UI that this location has to be waited on indefinitely. This applies to
* `single-pickup-multi-dropoff`, first pickup (initial loading) and last dropoff (end collection)
* `multi-pickup-single-dropoff`, last dropoff (end collection)

Notes
* added `staging` flag to `TaskDestination`
* Used `TaskDestination` in `RobotStatus` instead of `Location`
* Removed unused `Location` model (I'm pretty sure it's unused)
