### PR TITLE
Removes need for seperate user for SCAS

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ Add a `keycloak_config.json` to your working directory and set `export ENABLE_KE
 {
     "server_url": "http://localhost:8080/",
     "realm": "master",
-    "client_id": "YOUR CLIENT",
-    "client_secret":"YOUR SECRET"
 }
 ```
 Note: we do need the admin api in order to perform some of the verification.

--- a/smart_cart_api_server/controllers/compartment_authorization.py
+++ b/smart_cart_api_server/controllers/compartment_authorization.py
@@ -18,8 +18,7 @@ async def get_compartment_authorization(
     print("Attempting keycloak connection")
     # Check if user exists
     if keycloak_client is not None:
-        keycloak_token = await keycloak_client.get_token()
-        if not await keycloak_client.check_user_exists(keycloak_token, user_info.adid):
+        if not await keycloak_client.check_user_exists(headers, user_info.adid):
             print("User was not found in keycloak")
             return False
 

--- a/smart_cart_api_server/keycloak/parse_config.py
+++ b/smart_cart_api_server/keycloak/parse_config.py
@@ -5,34 +5,13 @@ from fastapi import HTTPException
 from urllib.parse import urljoin
 
 class KeyCloakClient:
-    def __init__(self, server_url, realm_name, client_id, client_secret_key) -> None:
+    def __init__(self, server_url, realm_name) -> None:
         self.server_url = server_url
         self.realm_name = realm_name
-        self.client_id = client_id
-        self.client_secret = client_secret_key
+        #self.client_id = client_id
+        #self.client_secret = client_secret_key
 
-    async def get_token(self) -> str:
-        async with aiohttp.ClientSession() as session:
-            form_data = FormData()
-            #grant_type=client_credentials&client_id=$client_id&client_secret=$client_secret
-            form_data.add_field('grant_type', 'client_credentials')
-            form_data.add_field('client_id', self.client_id)
-            form_data.add_field('client_secret', self.client_secret)
-            async with session.post(urljoin(self.server_url, f"/realms/{self.realm_name}/protocol/openid-connect/token"), data=form_data) as response:
-                if response.status != 200:
-                    raise HTTPException(
-                        status_code=401, detail=f"Could not get keycloak token"
-                    )
-                parsed = json.loads(await response.text())
-                if "access_token" in parsed:
-                    return parsed["access_token"]
-                raise HTTPException(
-                        status_code=401, detail=f"Keycloak token malformed"
-                    )
-
-
-    async def check_user_exists(self, token, user) -> bool:
-        headers = {"Authorization": f"Bearer {token}"}
+    async def check_user_exists(self, headers, user: str) -> bool:
         async with aiohttp.ClientSession(headers=headers) as session:
             async with session.get(urljoin(self.server_url, f"admin/realms/{self.realm_name}/users?username={user}")) as response:
                 if response.status != 200:
@@ -51,14 +30,7 @@ def keycloak_from_json(filename: str) -> KeyCloakClient:
         if "realm" not in config:
             raise "Could not find realm in config file"
 
-        if "client_id" not in config:
-            raise "Could not find client_id in config file"
-
-        if "client_secret" not in config:
-            raise "Could not find client_id in config file"
 
         return KeyCloakClient(
                         server_url=config["server_url"],
-                        realm_name=config["realm"],
-                        client_id=config["client_id"],
-                        client_secret_key=config["client_secret"])
+                        realm_name=config["realm"])


### PR DESCRIPTION
We simply forward the auth token held by the user, instead of using our
own token.
